### PR TITLE
Update EmptyStageSpec.c

### DIFF
--- a/assets/Stage/EmptyStageSpec.c
+++ b/assets/Stage/EmptyStageSpec.c
@@ -1,238 +1,100 @@
+// Gravity
+{
+    __I_TO_FIXED(0),
+    __F_TO_FIXED(0),
+    __I_TO_FIXED(0),
+},
+#!/usr/bin/env python3
+"""
+Example script to parse/modify certain fields of a VUEngine 'StageROMSpec' in C code.
+WARNING: This is a naive text-based approach, which could break if the formatting changes.
+A more robust approach would be to store config in JSON or parse with a real C parser.
+"""
+
+import re
+
+# The input .c snippet for the stage spec, truncated or loaded from file
+stage_code = r'''\
 /*
  * VUEngine Core
  *
- * © Jorge Eremiev <jorgech3@gmail.com> and Christian Radke <c.radke@posteo.de>
- *
- * For the full copyright and license information, please view the LICENSE file
- * that was distributed with this source code.
+ * ...
  */
-
-
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————
-// INCLUDES
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————
-
 #include <Stage.h>
-
-
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————
-// DEFINITIONS
-//——————————————————————————————————————————————————————————————————————————————————————————————————————————
 
 StageROMSpec EmptyStageSpec =
 {
-	// Class allocator
-	__TYPE(Stage),
-
-	// Timer config
-	{
-		__TIMER_100US,
-		1000,
-		kMS
-	},
-
-	// Sound config
-	{
-		__DEFAULT_PCM_HZ,
-		false
-	},
-
-	// General stage's attributes
-	{
-		// Stage's size in pixels
-		{
-			// x
-			__SCREEN_WIDTH,
-			// y
-			__SCREEN_HEIGHT,
-			// z
-			__SCREEN_DEPTH,
-		},
-
-		// Camera's initial position inside the stage
-		{
-			// x
-			0,
-			// y
-			0,
-			// z
-			0,
-			// p
-			0,
-		},
-
-		// Camera's frustum
+    // ...
+    // Physical world's properties
+    {
+        // Gravity
         {
-        	// x0
-        	0,
-        	// y0
-			0,
-			// z0
-			-10,
-        	// x1
-        	__SCREEN_WIDTH,
-        	// y1
-        	__SCREEN_HEIGHT,
-        	// z1
-        	__SCREEN_WIDTH * 5,
-        }
-	},
+            __I_TO_FIXED(0),
+            __F_TO_FIXED(0),
+            __I_TO_FIXED(0),
+        },
 
-	// Streaming
-	{
-		// Padding to be added to camera's frustum when checking if a entity spec
-		// describes an entity that is within the camera's range
-		40,
-		// Padding to be added to camera's frustum when checking if a entity is
-		// out of the camera's range
-		16,
-		// Amount of entity descriptions to check for streaming in entities
-		24,
-		// If true, entity instantiation is done over time
-		false,
-	},
+        // Friction coefficient
+        __F_TO_FIXED(0),
+    },
 
-	// Rendering
-	{
-		// Maximum number of texture's rows to write each time the texture writing is active
-		12,
+    // ...
+};'''
 
-		// Maximum number of rows to compute on each call to the affine functions
-		16,
+def main():
+    print("[Original code snippet]:\n")
+    print(stage_code)
 
-		// Color configuration
-		{
-			// Background color
-			__COLOR_BLACK,
+    # We'll do something naive: find the lines that define the gravity vector.
+    # We know it looks like:
+    #
+    # {
+    #     __I_TO_FIXED(0),
+    #     __F_TO_FIXED(0),
+    #     __I_TO_FIXED(0),
+    # },
+    #
+    # We'll match them with a multiline pattern capturing the values.
 
-			// Brightness
-			// These values times the repeat values specified in the column table (max. 16) make the final
-			// brightness values on the respective regions of the screen. maximum brightness is 128.
-			{
-				// Dark red
-				16,
-				// Medium red
-				__BRIGHTNESS_MEDIUM_RED,
-				// Bright red
-				__BRIGHTNESS_BRIGHT_RED,
-			},
+    pattern = re.compile(
+        r"""
+        \(            # A literal '('
+        __I_TO_FIXED\s*\(\s*(\d+)\s*\),  # capture integer inside
+        \s*__F_TO_FIXED\s*\(\s*(\d+\.?\d*)\s*\),
+        \s*__I_TO_FIXED\s*\(\s*(\d+)\s*\),
+        """,
+        re.VERBOSE,
+    )
 
-			// Brightness repeat
-			(BrightnessRepeatSpec*)NULL,
-		},
+    match = pattern.search(stage_code)
+    if not match:
+        print("\n[No gravity pattern found! Check your regex or code format.]")
+        return
 
-		// Palettes' configuration
-		{
-			{
-				// Bgmap palette 0
-				__BGMAP_PALETTE_0,
-				// Bgmap palette 1
-				__BGMAP_PALETTE_1,
-				// Bgmap palette 2
-				__BGMAP_PALETTE_2,
-				// Bgmap palette 3
-				__BGMAP_PALETTE_3,
-			},
-			{
-				// Object palette 0
-				__OBJECT_PALETTE_0,
-				// Object palette 1
-				__OBJECT_PALETTE_1,
-				// Object palette 2
-				__OBJECT_PALETTE_2,
-				// Object palette 3
-				__OBJECT_PALETTE_3,
-			},
-		},
+    # Suppose we want to change the gravity from (0, 0.0, 0) to (0, 0.45, 0)
+    # We'll keep the first captured group as is, just for demonstration
+    old_i1, old_f, old_i2 = match.groups()
+    print(f"\n[Found gravity: X={old_i1}, Y={old_f}, Z={old_i2}]")
 
-		// Bgmap segments configuration
-		// Number of BGMAP segments reserved for the param
-		1,
+    # Let's define new values:
+    new_i1 = "0"
+    new_f  = "0.45"
+    new_i2 = "0"
 
-		// Object segments' sizes (__spt0 to __spt3, up to 1024 in total)
-		// Can impact performance, make sure to configure only as large as maximally needed
-		{
-			// __spt0
-			0,
-			// __spt1
-			0,
-			// __spt2
-			0,
-			// __spt3
-			0,
-		},
+    # We'll do a replacement. We'll produce the new text that replaces the entire block
+    # We insert the new numeric values into the placeholders.
+    replacement_text = (
+        f"(__I_TO_FIXED({new_i1}),\n"
+        f"            __F_TO_FIXED({new_f}),\n"
+        f"            __I_TO_FIXED({new_i2}),"
+    )
 
-		// Object segments' z coordinates (__spt0 to __spt3)
-		// Note that each spt's z coordinate much be larger than or equal to the previous one's,
-		// since the vip renders obj worlds in reverse order (__spt3 to __spt0)
-		{
-			// __spt0
-			0,
-			// __spt1
-			0,
-			// __spt2
-			0,
-			// __spt3
-			0,
-		},
+    # We'll transform the code
+    updated_code = pattern.sub(replacement_text, stage_code)
 
-		// Struct defining the optical settings for the stage
-		{
-			// Maximum view distance's power into the horizon
-			__MAXIMUM_X_VIEW_DISTANCE, __MAXIMUM_Y_VIEW_DISTANCE,
-			// Distance of the eyes to the screen
-			__CAMERA_NEAR_PLANE,
-			// Distance from left to right eye (depth sensation)
-			__BASE_FACTOR,
-			// Horizontal view point center
-			__HORIZONTAL_VIEW_POINT_CENTER,
-			// Vertical view point center
-			__VERTICAL_VIEW_POINT_CENTER,
-			// Scaling factor
-			__SCALING_MODIFIER_FACTOR,
-		},
-	},
+    print("\n[Updated code snippet]:\n")
+    print(updated_code)
 
-	// Physical world's properties
-	{
-		// Gravity
-		{
-			__I_TO_FIXED(0),
-			__F_TO_FIXED(0),
-			__I_TO_FIXED(0),
-		},
 
-		// Friction coefficient
-		__F_TO_FIXED(0),
-	},
-
-	// Assets
-	{
-		// Fonts to preload
-		(FontSpec**)NULL,
-
-		// CharSets to preload
-		(CharSetSpec**)NULL,
-
-		// Textures to preload
-		(TextureSpec**)NULL,
-
-		// background sounds
-		(SoundSpec**)NULL,
-	},
-
-	// Entities
-	{
-		// UI configuration
-		{
-			(PositionedEntity*)NULL,
-			__TYPE(UIContainer),
-		},
-
-		// Stage's children entities
-		(PositionedEntity*)NULL,
-	},
-
-	// Post processing effects
-	(PostProcessingEffect*)NULL,
-};
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. Verify Understanding You’ve shared a C code snippet that defines a global StageROMSpec named EmptyStageSpec for VUEngine (a Virtual Boy engine). This struct configures various stage parameters—timers, sound, rendering layers, camera frustum, physics, etc.—for an empty stage. The code looks like a typical “scene definition” or “level definition” that VUEngine uses to initialize a level at runtime.

Sometimes you may want to programmatically parse or modify such C struct initializers outside of the main code—for instance, to generate, update, or validate them automatically in a build pipeline. Unlike YAML or JSON, there’s no single standard parser for C initialization syntax. You typically either:

Use regex or manual text parsing to locate the relevant fields and update them. Employ a small C parser or AST library (like Clang’s LibTooling) to parse the code at an abstract level. Keep the data in a more structured format (like JSON, TOML, or YAML) and generate this .c snippet, which is how many engines handle external data. Below, I’ll demonstrate a naive Python approach that searches the source code for certain patterns (via regex) to tweak, for example, the gravity or rendering parameters. This is obviously fragile if the structure changes or the code formatting shifts, but it can work if your code is consistent.

2. Outline Approach Identify Patterns: For instance, we see the gravity vector is:

c
Copy code
// Gravity
{
    __I_TO_FIXED(0),
    __F_TO_FIXED(0),
    __I_TO_FIXED(0),
},
We can search for that pattern and replace it with new values.

Regex: Use a pattern that captures the numeric arguments to __I_TO_FIXED(...) or __F_TO_FIXED(...).

Replace: Construct a new snippet with updated values.

We’ll illustrate gravity changes as an example, but the same technique can apply to other fields (like m_DefaultRenderingPath in a previous example).

3. Example Python Script (Naive Regex Approach) python
Copy code
#!/usr/bin/env python3
"""
Example script to parse/modify certain fields of a VUEngine 'StageROMSpec' in C code. WARNING: This is a naive text-based approach, which could break if the formatting changes. A more robust approach would be to store config in JSON or parse with a real C parser. """

import re

# The input .c snippet for the stage spec, truncated or loaded from file stage_code = r'''\
/*
 * VUEngine Core *
 * ... */ #include <Stage.h>

StageROMSpec EmptyStageSpec =
{
    // ...
    // Physical world's properties
    {
        // Gravity
        {
            __I_TO_FIXED(0),
            __F_TO_FIXED(0),
            __I_TO_FIXED(0),
        },

        // Friction coefficient
        __F_TO_FIXED(0),
    },

    // ...
};'''

def main():
    print("[Original code snippet]:\n")
    print(stage_code)

    # We'll do something naive: find the lines that define the gravity vector.
    # We know it looks like:
    #
    # {
    #     __I_TO_FIXED(0),
    #     __F_TO_FIXED(0),
    #     __I_TO_FIXED(0),
    # },
    #
    # We'll match them with a multiline pattern capturing the values.

    pattern = re.compile(
        r"""
        \(            # A literal '('
        __I_TO_FIXED\s*\(\s*(\d+)\s*\),  # capture integer inside
        \s*__F_TO_FIXED\s*\(\s*(\d+\.?\d*)\s*\),
        \s*__I_TO_FIXED\s*\(\s*(\d+)\s*\),
        """,
        re.VERBOSE,
    )

    match = pattern.search(stage_code)
    if not match:
        print("\n[No gravity pattern found! Check your regex or code format.]")
        return

    # Suppose we want to change the gravity from (0, 0.0, 0) to (0, 0.45, 0)
    # We'll keep the first captured group as is, just for demonstration
    old_i1, old_f, old_i2 = match.groups()
    print(f"\n[Found gravity: X={old_i1}, Y={old_f}, Z={old_i2}]")

    # Let's define new values:
    new_i1 = "0"
    new_f  = "0.45"
    new_i2 = "0"

    # We'll do a replacement. We'll produce the new text that replaces the entire block
    # We insert the new numeric values into the placeholders.
    replacement_text = (
        f"(__I_TO_FIXED({new_i1}),\n"
        f"            __F_TO_FIXED({new_f}),\n"
        f"            __I_TO_FIXED({new_i2}),"
    )

    # We'll transform the code
    updated_code = pattern.sub(replacement_text, stage_code)

    print("\n[Updated code snippet]:\n")
    print(updated_code)


if __name__ == "__main__":
    main()
Explanation of Key Steps
stage_code: We embed the snippet as a Python string. In production, you might read it from a .c file on disk. Regex:
We compile a multiline pattern looking for lines with __I_TO_FIXED(...) and __F_TO_FIXED(...). We capture the numeric parts in groups ( … ).
If the formatting changes significantly (extra spaces, newlines, or comments), it might fail. Match & Replace:
We retrieve the old gravity values from the capturing groups. We build a replacement string with new values.
We do a single .sub(...) call.
Print: Show the result.
Note: This approach is purely text-based. If you want to do large-scale changes or ensure correctness, consider storing these stage specs in JSON or using advanced tooling:

C AST Parsing with Clang’s LibTooling or similar.
Data-First: Keep stage data in a structured format (like JSON or a custom script) and generate .c code from it. That’s often simpler than editing .c code in place.
4. Potential Enhancements Refactor for Multiple Fields: If you want to also replace e.g. the friction, camera position, or block of palettes, you can define more specialized regex patterns or write a small parser that identifies the nested curly braces. Error Handling: If the code snippet changes or the pattern is not found, fail gracefully. One Pass: If you’re changing multiple sections, do them in a single pass with multiple patterns or a small “parse tree” approach. Conclusion
This snippet demonstrates a naive but workable approach to script-based modifications of a VUEngine’s StageROMSpec in C. It is fragile (depends on consistent formatting) but can serve as a stepping stone. For robust solutions, prefer either advanced C AST tooling or keep these “data specs” in a more parse-friendly format (like JSON) and generate the .c stage definitions from it.